### PR TITLE
Gtars versioning docs

### DIFF
--- a/docs/bedbase/bedbase-loader.md
+++ b/docs/bedbase/bedbase-loader.md
@@ -6,7 +6,7 @@ This ensures that BEDbase stays up to date with the latest available genomic dat
 BEDbase loader repository: [https://github.com/databio/bedbase-loader](https://github.com/databio/bedbase-loader)
 
 ## Key Features
-- **Automated GEO Retrival**
+- **Automated GEO Retrieval**
 - **Automated BED heavy processing**
 - **Automated Genomes Updater**
 - **Umap creator**

--- a/docs/bedbase/img/oobr_schematic_detailed.svg
+++ b/docs/bedbase/img/oobr_schematic_detailed.svg
@@ -754,7 +754,7 @@
            id="tspan50-4-22-7-3-6-9-5-9-9-7"
            style="font-weight:normal;font-size:11px;letter-spacing:0px;fill:#000000;fill-opacity:0.953014;stroke:none;stroke-width:1.70079;stroke-opacity:1"
            x="4031.7566"
-           y="-499.36725">Measure Sensitivty of </tspan><tspan
+           y="-499.36725">Measure Sensitivity of </tspan><tspan
            sodipodi:role="line"
            style="font-weight:normal;font-size:11px;letter-spacing:0px;fill:#000000;fill-opacity:0.953014;stroke:none;stroke-width:1.70079;stroke-opacity:1"
            x="4031.7566"

--- a/docs/bedbase/user/bedbase-search.md
+++ b/docs/bedbase/user/bedbase-search.md
@@ -12,7 +12,7 @@ This search is a first tab in the search page, and is a default search.
 To use the search, provide **text query** (e.g., *“heart”*, or  *“k562”*) and click _search_.
 
 At this moment, we are using semantic search. Compared to traditional keyword-based search, semantic search understands the meaning behind your query, allowing for more relevant results.
-Most of the avaliable platforms (GEO, ENCODE, etc) use traditional search, that limits findability.
+Most of the available platforms (GEO, ENCODE, etc) use traditional search, that limits findability.
 
 How does it work?
 1. The query text is encoded into a vector using a pre-trained language model.  
@@ -45,16 +45,16 @@ Additionally, we have provided filters to narrow down your search results. You c
 which will combine metadata and BED content for more accurate results. Stay tuned for updates!
 
 ### 🟢 BED2BED Search 
-_(Avaliable only for hg38)_
+_(Available only for hg38)_
 
 BED to BED search allows you to find relevant BED files using your own BED file as a query.
 
-It is a poverfull way to find similar files to compare with your own data. This searchcan be used as a quality control step
+It is a powerful way to find similar files to compare with your own data. This search can be used as a quality control step
 of your own data, finding functional similarities to prove the correctness of your data,
 or just to find similar datasets for your analysis.
 
 To use the search, go to the second tab of the search page, and
-upload your BED file. This bed file should be less then 20MB and should be a valid BED format.
+upload your BED file. This bed file should be less than 20MB and should be a valid BED format.
 BED-like file can be both gzipped or unzipped, we will handle both formats. 😃
 
 After file has been uploaded, we are running quality control steps to make sure the file is valid.

--- a/docs/bedboss/tutorials/bedms_tutorial.md
+++ b/docs/bedboss/tutorials/bedms_tutorial.md
@@ -1,6 +1,6 @@
 ## BEDMS
 
-BEDMS (BED Metadata Standardizer) is a tool desgined to standardize genomics and epigenomics metadata attributes according to user-selected or user-trained schemas. BEDMS ensures consistency and FAIRness of metadata across different platforms. 
+BEDMS (BED Metadata Standardizer) is a tool designed to standardize genomics and epigenomics metadata attributes according to user-selected or user-trained schemas. BEDMS ensures consistency and FAIRness of metadata across different platforms. 
 Users can interact with BEDMS either through Python or via [PEPhub](https://pephub.databio.org/) choosing from predefined schemas provided by the tool. Additionally, BEDMS allows users to create and train custom schemas as per their project requirements. For detailed information on the available schemas, please visit [HuggingFace](https://huggingface.co/databio/attribute-standardizer-model6). 
 
 ### Installation

--- a/docs/gtars/README.md
+++ b/docs/gtars/README.md
@@ -13,7 +13,7 @@
 
 ## Introduction
 
-`gtars` is a high-performance toolkit for *genomic tools and algorithms in Rust*. Built with Rust for speed and reliability, gtars provides core utilies for machine learning on genomic intervals for the [geniml](https://github.com/databio/geniml) Python package. It also provides lots of utility as a standalone library for alternative downstream use cases.
+`gtars` is a high-performance toolkit for *genomic tools and algorithms in Rust*. Built with Rust for speed and reliability, gtars provides core utilities for machine learning on genomic intervals for the [geniml](https://github.com/databio/geniml) Python package. It also provides lots of utility as a standalone library for alternative downstream use cases.
 
 ## Installation
 

--- a/docs/gtars/versioning.md
+++ b/docs/gtars/versioning.md
@@ -1,0 +1,49 @@
+# Versioning policy for gtars and its crates
+Because `gtars` is organized as a [workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) with multiple crates, we need to ensure that we have a clear versioning policy for the different crates, bindings, and command line tools.
+
+The versioning and tagging scheme was influenced by several other Rust projects we admire/use:
+- `polars` https://github.com/pola-rs/polars/tags
+- `bigtools` https://github.com/jackh726/bigtools/releases
+- `noodles`https://github.com/zaeleus/noodles/tags?after=noodles-fastq-0.19.0
+
+## Versioning scheme
+In general, we will follow [Semantic Versioning](https://semver.org/) for all crates, bindings, and command line tools. We allow independent versioning for each crate, and we will bump the version(s) of any wrapper/binding/CLI crate that depends on a crate that has been updated.
+
+Finally, we also have a specific tagging scheme for releases on GitHub.
+
+## Tagging scheme
+- Core Rust Crates: vX.Y.Z (e.g., v0.5.2). This tag signifies a release of the core library crates to crates.io. It should trigger the cargo publish workflow.
+- Python Bindings: py-X.Y.Z (e.g., py-0.3.1). This tag signifies a release of the Python package to PyPI.
+- CLI: cli-X.Y.Z (e.g., cli-1.1.0). This tag signifies a release of the CLI binaries, which will be attached to a GitHub Release.
+- WASM Bindings: wasm-X.Y.Z (e.g., wasm-0.1.5). This tag signifies a release of the WASM package to npm.
+
+## An example scenario:
+
+Say we fix a bug in `uniwig`, we will bump its version by a single patch `x.x.1` inside its `Cargo.toml`:
+```diff
+- version="0.5.0"
++ version="0.5.1"
+```
+We publish this to `crates.io` using `cargo publish`.
+
+Then we will bump this version accordingly in the `gtars` wrapper crate **and** bump the crates version (since it got a new uniwig)
+```diff
+- gtars-uniwig = { version="0.5.0" }
++ gtars-uniwig = { version="0.5.1" }
+```
+```diff
+- version="0.5.11"
++ version="0.5.12"
+```
+We will publish this to `crates.io` using `cargo publish`
+
+FInally, because `uniwig` is a tool used in the command line interface, we will bump the version of `gtars-uniwig` in `gtars-cli` to the most recent version with the bug fix similarly to before. Then we will bump the version of `gtars-cli` as a whole (a single patch since its a simple bug fix in `gtars-uniwig`).
+```diff
+- gtars-uniwig = { version="0.5.0" }
++ gtars-uniwig = { version="0.5.1" }
+```
+```diff
+- version="0.4.1"
++ version="0.4.2"
+```
+We will publish this to `crates.io` using `cargo publish`

--- a/docs/gtars/versioning.md
+++ b/docs/gtars/versioning.md
@@ -2,9 +2,10 @@
 Because `gtars` is organized as a [workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) with multiple crates, we need to ensure that we have a clear versioning policy for the different crates, bindings, and command line tools.
 
 The versioning and tagging scheme was influenced by several other Rust projects we admire/use:
-- `polars` https://github.com/pola-rs/polars/tags
-- `bigtools` https://github.com/jackh726/bigtools/releases
-- `noodles`https://github.com/zaeleus/noodles/tags?after=noodles-fastq-0.19.0
+
+- `polars`: https://github.com/pola-rs/polars/tags
+- `bigtools`: https://github.com/jackh726/bigtools/releases
+- `noodles`: https://github.com/zaeleus/noodles/tags?after=noodles-fastq-0.19.0
 
 ## Versioning scheme
 In general, we will follow [Semantic Versioning](https://semver.org/) for all crates, bindings, and command line tools. We allow independent versioning for each crate, and we will bump the version(s) of any wrapper/binding/CLI crate that depends on a crate that has been updated.
@@ -12,15 +13,16 @@ In general, we will follow [Semantic Versioning](https://semver.org/) for all cr
 Finally, we also have a specific tagging scheme for releases on GitHub.
 
 ## Tagging scheme
-- Core Rust Crates: vX.Y.Z (e.g., v0.5.2). This tag signifies a release of the core library crates to crates.io. It should trigger the cargo publish workflow.
-- Python Bindings: py-X.Y.Z (e.g., py-0.3.1). This tag signifies a release of the Python package to PyPI.
-- CLI: cli-X.Y.Z (e.g., cli-1.1.0). This tag signifies a release of the CLI binaries, which will be attached to a GitHub Release.
-- WASM Bindings: wasm-X.Y.Z (e.g., wasm-0.1.5). This tag signifies a release of the WASM package to npm.
+- Core Rust Crates: `vX.Y.Z` (e.g., `v0.5.2`). This tag signifies a release of the core library crates to crates.io. It should trigger the cargo publish workflow.
+- Python Bindings: `py-X.Y.Z` (e.g., `py-0.3.1`). This tag signifies a release of the Python package to PyPI.
+- CLI: `cli-X.Y.Z` (e.g., `cli-1.1.0`). This tag signifies a release of the CLI binaries, which will be attached to a GitHub Release.
+- WASM Bindings: `wasm-X.Y.Z` (e.g., `wasm-0.1.5`). This tag signifies a release of the WASM package to npm.
 
 ## An example scenario:
 
 Say we fix a bug in `uniwig`, we will bump its version by a single patch `x.x.1` inside its `Cargo.toml`:
 ```diff
+// gtars-uniwig/Cargo.toml
 - version="0.5.0"
 + version="0.5.1"
 ```
@@ -28,16 +30,18 @@ We publish this to `crates.io` using `cargo publish`.
 
 Then we will bump this version accordingly in the `gtars` wrapper crate **and** bump the crates version (since it got a new uniwig)
 ```diff
+// gtars/Cargo.toml
 - gtars-uniwig = { version="0.5.0" }
 + gtars-uniwig = { version="0.5.1" }
 ```
 ```diff
+// gtars/Cargo.toml
 - version="0.5.11"
 + version="0.5.12"
 ```
 We will publish this to `crates.io` using `cargo publish`
 
-FInally, because `uniwig` is a tool used in the command line interface, we will bump the version of `gtars-uniwig` in `gtars-cli` to the most recent version with the bug fix similarly to before. Then we will bump the version of `gtars-cli` as a whole (a single patch since its a simple bug fix in `gtars-uniwig`).
+Finally, because `uniwig` is a tool used in the command line interface, we will bump the version of `gtars-uniwig` in `gtars-cli` to the most recent version with the bug fix similarly to before. Then we will bump the version of `gtars-cli` as a whole (a single patch since its a simple bug fix in `gtars-uniwig`).
 ```diff
 - gtars-uniwig = { version="0.5.0" }
 + gtars-uniwig = { version="0.5.1" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
     - Reference:
       - Changelog: gtars/changelog.md
       - Rust source API docs: https://docs.rs/gtars/latest/gtars/
+      - Versioning policy: gtars/versioning.md
   - Manuscripts: 
     - How to cite: citations.md
     - Published manuscripts:


### PR DESCRIPTION
Single page added to go over how the `gtars` workspace needs to be versioned/tagged